### PR TITLE
Quick fix on zombie head bug where it spawns 2 blocks up to the ground.

### DIFF
--- a/src/main/java/com/extrahardmode/features/monsters/Zombies.java
+++ b/src/main/java/com/extrahardmode/features/monsters/Zombies.java
@@ -133,7 +133,7 @@ public class Zombies extends ListenerModule
                         if (!block.getType().isSolid())
                         {
                             Location location = block.getLocation();
-                            location.setY(location.getY() + 1);
+                            location.setY(location.getY());
                             block = location.getBlock();
                         }
                         block.setType(Material.SKULL);

--- a/src/main/java/com/extrahardmode/features/monsters/Zombies.java
+++ b/src/main/java/com/extrahardmode/features/monsters/Zombies.java
@@ -130,10 +130,10 @@ public class Zombies extends ListenerModule
                     {
                         Block block = entity.getLocation().getBlock();
                         //Don't replace blocks that aren't air, but aren't solid either
-                        if (!block.getType().isSolid())
+                        if (block.getType() != Material.AIR)
                         {
                             Location location = block.getLocation();
-                            location.setY(location.getY());
+                            location.setY(location.getY()+1);
                             block = location.getBlock();
                         }
                         block.setType(Material.SKULL);
@@ -143,7 +143,7 @@ public class Zombies extends ListenerModule
                         BlockFace[] faces = BlockModule.getHorizontalAdjacentFaces();
                         skull.setRotation(faces[OurRandom.nextInt(faces.length)]);
                         skull.update();
-                        tempBlock = temporaryBlockHandler.addTemporaryBlock(entity.getLocation(), "respawn_skull");
+                        tempBlock = temporaryBlockHandler.addTemporaryBlock(skull.getLocation(), "respawn_skull");
                     }
                     RespawnZombieTask task = new RespawnZombieTask(plugin, entity.getLocation(), player, tempBlock);
                     int respawnSeconds = plugin.getRandom().nextInt(6) + 3; // 3-8 seconds


### PR DESCRIPTION
I think it has something to do with changes on 1.9.2 spigot api strangely enough the head still floating like 1/3 of block

Here is the video of the bug using 3.8
https://www.youtube.com/watch?v=0kVwGrY5HYo

Here is a comparison head between the zombie head feature of EHM and just a normal zombie head placed by a player this is the one with the fixed given

http://i.imgur.com/IafOigB.png

Also feel free to check it out yourself to confirm the bug :D

