### PR TITLE
Fixed Pigmen damage Reduction not working

### DIFF
--- a/src/main/java/com/extrahardmode/features/monsters/PigMen.java
+++ b/src/main/java/com/extrahardmode/features/monsters/PigMen.java
@@ -152,8 +152,8 @@ public class PigMen extends ListenerModule
     @EventHandler
     public void onPlayerDamaged(EntityDamageByEntityEvent event)
     {
-        int damagePercentage = CFG.getInt(RootNode.PIG_ZOMBIE_DMG_PERCENT, event.getEntity().getWorld().getName()) / 100;
-        if (damagePercentage <= 0)
+        double damagePercentage = CFG.getInt(RootNode.PIG_ZOMBIE_DMG_PERCENT, event.getEntity().getWorld().getName()) / 100.0;
+        if (damagePercentage <= 0.0)
             return;
         if (event.getEntity() instanceof Player && event.getDamager() instanceof PigZombie)
         {


### PR DESCRIPTION
You calculate damage reduction by an integer, integers can only hold whole numbers.

Thus, when you calculate the damage reduction by CONFIG_VALUE / 100, it just gets rounded down to 0 

(Assuming the config value is less than 100, otherwise it will get rounded down to the closest whole number).