### PR TITLE
Update 1.13+ blocks

### DIFF
--- a/src/main/java/com/extrahardmode/task/RemoveExposedTorchesTask.java
+++ b/src/main/java/com/extrahardmode/task/RemoveExposedTorchesTask.java
@@ -125,17 +125,18 @@ public class RemoveExposedTorchesTask implements Runnable
                                 }
                                 break loopDown;
                             }
-                            case WHEAT_SEEDS: //TODO: 1.13: need to confirm if = CROPS and below
                             case MELON_STEM:
+                            case ATTACHED_MELON_STEM:
                             case MELON:
-                            case CARROT:
+                            case CARROTS:
                             case PUMPKIN_STEM:
-                            case POTATO:
+                            case ATTACHED_PUMPKIN_STEM:
+                            case PUMPKIN: //I followed suit with the melon and added pumpkin
+                            case POTATOES:
                             case ROSE_BUSH: //RED_ROSE //ROSE_RED
                             case DANDELION: //YELLOW FLOWER
                             case GRASS: //I still can't recall if the replacement for LONG_GRASS is GRASS or TALL_GRASS...
                             case TALL_GRASS:
-                            case BEETROOT_SEEDS: //BEETROOT_BLOCK
                             case BEETROOTS:
                             {
                                 if (snowBreaksCrops && temperature <= 0.15) //cold biomes in which snow falls


### PR DESCRIPTION
- Fixed some of the updated 1.13+ blocks

When I was doing the campfire PR I noticed some of these blocks weren't updated, so I figured I'd take care of them.

In regards to your note for the GRASS/TALL_GRASS
GRASS = the small grass plant
TALL_GRASS = the double tall grass plant
So yes, the way its done is correct (if that was your intention to replace grass plants with snow)

I noticed MELON blocks were on the list so I added PUMPKIN blocks to follow suit, Im not sure if you wanted this, I just thought consistency made sense.