### PR TITLE
BlockPhysicsCheckTask - add CAVE_AIR check

### DIFF
--- a/src/main/java/com/extrahardmode/task/BlockPhysicsCheckTask.java
+++ b/src/main/java/com/extrahardmode/task/BlockPhysicsCheckTask.java
@@ -94,8 +94,9 @@ public class BlockPhysicsCheckTask implements Runnable
 
         Material material = block.getType();
         Block underBlock = block.getRelative(BlockFace.DOWN);
+        Material underType = underBlock.getType();
 
-        if ((underBlock.getType() == Material.AIR || underBlock.isLiquid() || underBlock.getType() == Material.TORCH)
+        if ((underType == Material.AIR || underType == Material.CAVE_AIR || underBlock.isLiquid() || underType == Material.TORCH)
                 && (material == Material.SAND || material == Material.GRAVEL || fallingBlocks.contains(block.getType())
                 && fallingBlocksEnabled && material != Material.AIR))
         {


### PR DESCRIPTION
This PR fixes an issue with blocks not falling when cave air is below them.

See issue #217 

I also added a field for material type for the underBlock to cut down calls for Block#getType