### PR TITLE
[Fix] bug that we can attach torch via grass

### DIFF
--- a/src/main/java/com/extrahardmode/features/Torches.java
+++ b/src/main/java/com/extrahardmode/features/Torches.java
@@ -39,12 +39,13 @@ import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Directional;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.weather.WeatherChangeEvent;
-import org.bukkit.material.Torch;
 
 /**
  * Torches
@@ -123,9 +124,14 @@ public class Torches extends ListenerModule
 
             if (LooseTags.TORCH.isTagged(blockType))
             {
-//                Torch torch = new Torch(blockType);
-//                Material attachmentMaterial = block.getRelative(torch.getAttachedFace()).getType();
-                Material attachmentMaterial = placeEvent.getBlockAgainst().getType();
+
+                BlockData blockData = block.getBlockData();
+                Material attachmentMaterial = (blockData instanceof Directional)
+                        // wall torch
+                        ? block.getRelative(((Directional) blockData).getFacing().getOppositeFace()).getType() 
+                        // torch on ground
+                        : block.getRelative(BlockFace.DOWN).getType();
+
                 switch (attachmentMaterial)
                 {
                     case DIRT:


### PR DESCRIPTION
Now we cannot put torch [in this case](https://user-images.githubusercontent.com/26216029/89056443-fbb94680-d396-11ea-9d32-59e24d642428.png).

Before, EHM checked block against placed block.
When we click grass, `placeEvent.getBlockAgainst()` returns `WALL_TORCH`.
This is because clicked block was grass. But real location on which torch will be placed is grass location.
[Like this](https://user-images.githubusercontent.com/26216029/89056470-02e05480-d397-11ea-9ad9-cec4119b76a8.png).
As a result, EHM think "Clicked block was not soft, torch can be attached here".