### PR TITLE
Fixed buckets of fish not being included in water evaporation.

### DIFF
--- a/src/main/java/com/extrahardmode/features/AntiFarming.java
+++ b/src/main/java/com/extrahardmode/features/AntiFarming.java
@@ -230,11 +230,15 @@ public class AntiFarming extends ListenerModule
 
         final boolean dontMoveWaterEnabled = CFG.getBoolean(RootNode.DONT_MOVE_WATER_SOURCE_BLOCKS, world.getName());
 
-        // FEATURE: can't move water source blocks
+        // FEATURE: can't move water source blocks, including buckets of fish
         if (dontMoveWaterEnabled)
         {
+            Material material = event.getItem().getType();
+
             // only care about water
-            if (event.getItem().getType() == Material.WATER_BUCKET)
+            if (material == Material.WATER_BUCKET || material == Material.COD_BUCKET ||
+                material == Material.PUFFERFISH_BUCKET || material == Material.SALMON_BUCKET ||
+                material == Material.TROPICAL_FISH_BUCKET)
             {
                 // plan to evaporate the water next tick
                 Block block = event.getVelocity().toLocation(world).getBlock();
@@ -394,8 +398,13 @@ public class AntiFarming extends ListenerModule
         final boolean dontMoveWaterEnabled = CFG.getBoolean(RootNode.DONT_MOVE_WATER_SOURCE_BLOCKS, world.getName());
         final boolean playerBypasses = playerModule.playerBypasses(player, Feature.ANTIFARMING);
 
-        // FEATURE: can't move water source blocks
-        if (!playerBypasses && dontMoveWaterEnabled && (event.getBucket() != Material.LAVA_BUCKET && event.getBucket() != Material.MILK_BUCKET))
+        Material material = event.getBucket();
+
+        // FEATURE: can't move water source blocks, including buckets of fish
+        if (!playerBypasses && dontMoveWaterEnabled &&
+                (material == Material.WATER_BUCKET || material == Material.COD_BUCKET ||
+                material == Material.PUFFERFISH_BUCKET || material == Material.SALMON_BUCKET ||
+                material == Material.TROPICAL_FISH_BUCKET))
         {
             // plan to change this block into a non-source block on the next tick
             Block block = event.getBlock();


### PR DESCRIPTION
This fixes #247 because I realized how painfully easy this was likely to fix. This may likely need to be updated again if Mojang ever decides to add more buckets of fish, but I would guess it would be unlikely given how long fishing has been in.

**Note: my Java is very rusty so I'm not sure of best practices. I assigned the materials to a variable before the `if` because I assumed every `get()` would see a 1ns performance hit. I'm just used to doing it like that in C#.*