### PR TITLE
Add blacklisted buckets for dispense event

### DIFF
--- a/src/main/java/com/extrahardmode/features/AntiFarming.java
+++ b/src/main/java/com/extrahardmode/features/AntiFarming.java
@@ -234,7 +234,12 @@ public class AntiFarming extends ListenerModule
         if (dontMoveWaterEnabled)
         {
             // only care about water
-            if (event.getItem().getType() == Material.WATER_BUCKET)
+            Material item = event.getItem().getType();
+            if (item == Material.WATER_BUCKET
+                    || item == Material.COD_BUCKET
+                    || item == Material.SALMON_BUCKET
+                    || item == Material.TROPICAL_FISH_BUCKET
+                    || item == Material.PUFFERFISH_BUCKET)
             {
                 // plan to evaporate the water next tick
                 Block block = event.getVelocity().toLocation(world).getBlock();


### PR DESCRIPTION
Added blacklisted buckets for material check on dispenser dispense event.

Simply deny use of fish bucket from dispensers.

This PR is divided from #233 and closes #248
 