### PR TITLE
Make scoreboard wider

### DIFF
--- a/src/main/java/de/diemex/scoreboardnotifier/NotificationHolder.java
+++ b/src/main/java/de/diemex/scoreboardnotifier/NotificationHolder.java
@@ -72,7 +72,7 @@ public class NotificationHolder
         {
             if (sb.length() != 0)
                 sb.append(" ");
-            Validate.isTrue(line.length() <= 16, "Scoreboards have a max of 16 characters per line. Given line was " + line.length() + " long. Content: \"" + line + "\"");
+            Validate.isTrue(line.length() <= 40, "Scoreboards have a max of 40 characters per line. Given line was " + line.length() + " long. Content: \"" + line + "\"");
             sb.append(line);
         }
         this.msgText = sb.toString();

--- a/src/main/java/de/diemex/scoreboardnotifier/message/StringUtil.java
+++ b/src/main/java/de/diemex/scoreboardnotifier/message/StringUtil.java
@@ -65,7 +65,7 @@ public class StringUtil
 
         MsgLineHolder line = new MsgLineHolder();
         int offset = 0;
-        int maxLineLength = lineColor != null ? 14 : 16; //Reserve 2 chars for the color code
+        int maxLineLength = lineColor != null ? 38 : 40; //Reserve 2 chars for the color code
         //Append every word to a line
         for (int i = 0; i < words.length; i++)
         {


### PR DESCRIPTION
The maximum scoreboard length is now 40 characters, not 16. Tested with spigot 1.17.
Closes #111 