### PR TITLE
Fix Java17 Specific issues and remove DESERT_HILLS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <version>3.15.0</version>
     <name>ExtraHardMode</name>
     <description>New game rules and mechanics for Minecraft.</description>
-    <url>http://dev.bukkit.org/projects/fun-hard-mode</url>
+    <url>https://dev.bukkit.org/projects/fun-hard-mode</url>
 
     <!-- Properties -->
     <properties>
@@ -166,11 +166,11 @@
         </repository>
         <repository>
             <id>github-releases</id>
-            <url>http://di3mex.github.io/repo_bukkit/releases/</url>
+            <url>https://di3mex.github.io/repo_bukkit/releases/</url>
         </repository>
         <repository>
             <id>github-snapshots</id>
-            <url>http://di3mex.github.io/repo_bukkit/snapshots/</url>
+            <url>https://di3mex.github.io/repo_bukkit/snapshots/</url>
         </repository>
         <!--<repository>-->
             <!--<id>prism-repo</id>-->
@@ -178,21 +178,21 @@
         <!--</repository>-->
         <repository>
             <id>md_5-releases</id>
-            <url>http://repo.md-5.net/content/repositories/releases/</url>
+            <url>https://repo.md-5.net/content/repositories/releases/</url>
         </repository>
         <repository>
             <id>md_5-snapshots</id>
-            <url>http://repo.md-5.net/content/repositories/snapshots/</url>
+            <url>https://repo.md-5.net/content/repositories/snapshots/</url>
         </repository>
         <!-- Spigot Repo -->
         <repository>
             <id>spigot-repo</id>
-            <url>http://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <!--WorldGuard Repo -->
         <repository>
             <id>sk89q-repo</id>
-            <url>http://maven.sk89q.com/repo/</url>
+            <url>https://maven.sk89q.com/repo/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,14 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -243,33 +251,33 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <!-- Mock bukkit's interfaces -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
         <!-- Mock final methods and stuff -->
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.5</version>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>1.5</version>
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.5</version>
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0-SNAPSHOT</version>
                 <configuration>
                     <minimizeJar>true</minimizeJar>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
@@ -207,6 +207,13 @@
             <url>http://localhost:8081/nexus/content/groups/public/</url>
         </repository>-->
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache.snapshots</id>
+            <url>https://repository.apache.org/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <!-- Dependencies -->
     <dependencies>

--- a/src/main/java/com/extrahardmode/features/AntiFarming.java
+++ b/src/main/java/com/extrahardmode/features/AntiFarming.java
@@ -210,7 +210,7 @@ public class AntiFarming extends ListenerModule
         if (aridDesertsEnabled)
         {
             Biome biome = block.getBiome();
-            if (biome == Biome.DESERT || biome == Biome.DESERT_HILLS)
+            if (biome == Biome.DESERT)
             {
                 event.setCancelled(true);
             }

--- a/src/main/java/com/extrahardmode/features/Tutorial.java
+++ b/src/main/java/com/extrahardmode/features/Tutorial.java
@@ -267,7 +267,6 @@ public class Tutorial extends ListenerModule
                     switch (block.getBiome())
                     {
                         case DESERT:
-                        case DESERT_HILLS:
                         {
                             messenger.send(player, MessageNode.ANTIFARMING_DESSERT_WARNING);
                             break;

--- a/src/main/java/com/extrahardmode/module/BlockModule.java
+++ b/src/main/java/com/extrahardmode/module/BlockModule.java
@@ -239,7 +239,7 @@ public class BlockModule extends EHMModule
                         Biome biome = block.getBiome();
 
                         // the desert environment is very rough on crops
-                        if ((biome == Biome.DESERT || biome == Biome.DESERT_HILLS) && aridDesertsEnabled)
+                        if ((biome == Biome.DESERT) && aridDesertsEnabled)
                         {
                             deathProbability += 50;
                         }

--- a/src/test/com/extrahardmode/mocks/MockBlock.java
+++ b/src/test/com/extrahardmode/mocks/MockBlock.java
@@ -27,7 +27,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/com/extrahardmode/service/TestMultiWorldConfig.java
+++ b/src/test/com/extrahardmode/service/TestMultiWorldConfig.java
@@ -31,6 +31,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.PluginLogger;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -86,6 +87,7 @@ public class TestMultiWorldConfig
 
 
     @Before
+    @Test
     public void prepare()
     {
         //normal values


### PR DESCRIPTION
- Using the 3.3.0 maven shade plugin that supports java17
- Changed all repo links from http to https cause otherwise maven complains and there is no point in keeping them http anymore.
- Fixed tests by making some changes to the files, updating the test deps and using two java args as a workaround for the [Java Platform Module System](https://openjdk.java.net/projects/jigsaw/spec/sotms/) introduced in Java9. This is only a temporary workaround, but works good enough for now.
- Removed DESERT_HILLS from the code because the biome has been removed in mc 1.18.