### PR TITLE
Update appveyor to java17

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,24 +3,15 @@ skip_tags: true
 clone_depth: 2
 environment:
   matrix:
-  - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  - appveyor_build_worker_image: Visual Studio 2022
+    JAVA_HOME: C:\Program Files\Java\jdk17
 branches:
   only:
   - master
-  except:
-  - gh-pages
 os: Windows Server 2012
 install:
-- ps: |
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    if (!(Test-Path -Path "C:\maven" )) {
-      (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip', 'C:\maven-bin.zip')
-      [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
-    }
-- cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
-- cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
-- cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
-- cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
+- cmd: SET MAVEN_OPTS=-Xmx4g
+- cmd: SET JAVA_OPTS=-Xmx4g
 - cmd: mvn --version
 - cmd: java -version
 build_script:
@@ -28,7 +19,6 @@ build_script:
 test_script:
 - mvn clean install --batch-mode -Pqulice
 cache:
-- C:\maven\
 - C:\Users\appveyor\.m2
 artifacts:
 - path: target/ExtraHardMode.jar

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <project.mainclass>com.extrahardmode.ExtraHardMode</project.mainclass>
         <!--Use a profile to overwrite this-->
         <outputdir>${project.build.outputDirectory}</outputdir>
-        <mc-version>1.17.1</mc-version>
+        <mc-version>1.18</mc-version>
         <bukkit-ver>R0.1-SNAPSHOT</bukkit-ver>
         <testDir>${basedir}/src/test/</testDir>
         <srcDir>${basedir}/src/main/java/</srcDir>
@@ -66,8 +66,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Following TechFortress/GriefPrevention#1663 as a reference, fix appveyor and update to java 17.
This will produce a build, assuming #292 #296 are merged.