### PR TITLE
remove non-void EventHandlers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.3.0</version>
                 <configuration>
                     <minimizeJar>true</minimizeJar>
                     <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/pom.xml
+++ b/pom.xml
@@ -199,8 +199,8 @@
         </repository>
         <!--WorldGuard Repo -->
         <repository>
-            <id>sk89q-repo</id>
-            <url>https://maven.sk89q.com/repo/</url>
+            <id>enginehub-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>

--- a/src/main/java/com/extrahardmode/features/AntiGrinder.java
+++ b/src/main/java/com/extrahardmode/features/AntiGrinder.java
@@ -82,13 +82,22 @@ public class AntiGrinder extends ListenerModule
     }
 
 
+    @EventHandler(priority = EventPriority.LOW)
+    public void onEntitySpawn(CreatureSpawnEvent event) {
+        event.setCancelled(!handleEntitySpawn(event));
+    }
+
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        handleEntityDeath(event);
+    }
+
     /**
      * When an Animal/Monster spawns check if the Location is "natural"
      *
      * @return true succeeded and false if cancelled or marked lootless
      */
-    @EventHandler(priority = EventPriority.LOW)
-    public boolean onEntitySpawn(CreatureSpawnEvent event)
+    public boolean handleEntitySpawn(CreatureSpawnEvent event)
     {
         Location location = event.getLocation();
         World world = location.getWorld();
@@ -120,21 +129,18 @@ public class AntiGrinder extends ListenerModule
                         case NORMAL:
                             if (!blockModule.isNaturalSpawnMaterial(underBlockType))
                             {
-                                event.setCancelled(true);
                                 return false;
                             }
                             break;
                         case NETHER:
                             if (!blockModule.isNaturalNetherSpawn(underBlockType))
                             {
-                                event.setCancelled(true);
                                 return false;
                             }
                             break;
                         case THE_END:
                             if (underBlockType != Material.END_STONE && underBlockType != Material.OBSIDIAN && underBlockType != Material.AIR/*dragon*/)
                             {
-                                event.setCancelled(true);
                                 return false;
                             }
                             break;
@@ -153,8 +159,7 @@ public class AntiGrinder extends ListenerModule
      *
      * @return true if drops loot, false if loot was blocked
      */
-    @EventHandler
-    public boolean onEntityDeath(EntityDeathEvent event)
+    public boolean handleEntityDeath(EntityDeathEvent event)
     {
         LivingEntity entity = event.getEntity();
         World world = entity.getWorld();

--- a/src/test/com/extrahardmode/features/TestAntiGrinder.java
+++ b/src/test/com/extrahardmode/features/TestAntiGrinder.java
@@ -63,10 +63,10 @@ public class TestAntiGrinder
     public void spawnerSpawns()
     {
         CreatureSpawnEvent event = new MockCreatureSpawnEvent(EntityType.BLAZE, "world", CreatureSpawnEvent.SpawnReason.SPAWNER).get();
-        assertFalse("Spawners should drop no exp", module.onEntitySpawn(event));
+        assertFalse("Spawners should drop no exp", module.handleEntitySpawn(event));
 
         event = new MockCreatureSpawnEvent(EntityType.ENDERMAN, "world", CreatureSpawnEvent.SpawnReason.SPAWNER).get();
-        assertFalse("Spawners should drop no exp", module.onEntitySpawn(event));
+        assertFalse("Spawners should drop no exp", module.handleEntitySpawn(event));
     }
 
 
@@ -92,7 +92,7 @@ public class TestAntiGrinder
         MockWorld world = event.getWorld();
         world.setEnvironment(World.Environment.NORMAL);
 
-        assertTrue("Zombie spawn succeeds", module.onEntitySpawn(event.get()));
+        assertTrue("Zombie spawn succeeds", module.handleEntitySpawn(event.get()));
     }
 
 
@@ -118,7 +118,7 @@ public class TestAntiGrinder
         MockWorld world = event.getWorld();
         world.setEnvironment(World.Environment.NETHER);
 
-        assertTrue("Natural spawn in the Nether failed", module.onEntitySpawn(event.get()));
+        assertTrue("Natural spawn in the Nether failed", module.handleEntitySpawn(event.get()));
 
 
         world.setEnvironment(World.Environment.NETHER);
@@ -127,7 +127,7 @@ public class TestAntiGrinder
         relative.setMaterial(Material.COBBLESTONE);
         block.setRelative(BlockFace.DOWN, relative.get());
 
-        assertFalse("Natural spawn in a not natural Location succeeded", module.onEntitySpawn(event.get()));
+        assertFalse("Natural spawn in a not natural Location succeeded", module.handleEntitySpawn(event.get()));
 
 
         //NetherRack doesn't spawn in the OverWorld
@@ -136,6 +136,6 @@ public class TestAntiGrinder
 
         world.setEnvironment(World.Environment.NORMAL);
 
-        assertFalse("Spawn on NetherRack in the OverWorld should have failed", module.onEntitySpawn(event.get()));
+        assertFalse("Spawn on NetherRack in the OverWorld should have failed", module.handleEntitySpawn(event.get()));
     }
 }


### PR DESCRIPTION
someone (I believe a user, not developer— apologies if someone else was planning on doing this) mentioned in the paper discord that paper was complaining about non-void EventHandlers in ExtraHardMode. thought I would make a pr resolving this.

For context, the log message was added because this was never really supported and someone was complaining about how paper broke handlers returning a long/double.