### PR TITLE
Fix TNT Explosions not being bigger

### DIFF
--- a/src/main/java/com/extrahardmode/features/Explosions.java
+++ b/src/main/java/com/extrahardmode/features/Explosions.java
@@ -119,7 +119,7 @@ public class Explosions extends ListenerModule
         // TNT
         if (sourceEntity instanceof TNTPrimed)
         {
-            if (customTntExplosion && event.blockList().size() > 0 && (flyOtherPlugins || event.getYield() == 1.0)) //getYield value of 1.0 somewhat ensures this is a vanilla TNT explosion.
+            if (customTntExplosion && event.blockList().size() > 0 && (flyOtherPlugins || event.getYield() == 1.0)) //getYield value of 1.0 (previously 0.25) somewhat ensures this is a vanilla TNT explosion.
             {
                 if (!multipleExplosions)
                 {

--- a/src/main/java/com/extrahardmode/features/Explosions.java
+++ b/src/main/java/com/extrahardmode/features/Explosions.java
@@ -119,7 +119,7 @@ public class Explosions extends ListenerModule
         // TNT
         if (sourceEntity instanceof TNTPrimed)
         {
-            if (customTntExplosion && event.blockList().size() > 0 && (flyOtherPlugins || event.getYield() == 0.25)) //getYield value of 0.25 somewhat ensures this is a vanilla TNT explosion.
+            if (customTntExplosion && event.blockList().size() > 0 && (flyOtherPlugins || event.getYield() == 1.0)) //getYield value of 1.0 somewhat ensures this is a vanilla TNT explosion.
             {
                 if (!multipleExplosions)
                 {


### PR DESCRIPTION
tnt yield is 1.0 (according to debugger) but was hardcoded to be 0.25 during checks for vanilla tnt

fixes #327 

tested in 1.21.1 with paper-1.21.1-132.jar by:
placing and lighting TNT
sets off multiple explosions making a nice big hole of ~15 blocks diameter in stone