### PR TITLE
[codex] Fix Bukkit test bootstrap on JDK 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.5.5</version>
                 <configuration>
                     <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
                 </configuration>
@@ -270,26 +270,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.1.0</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- Mock final methods and stuff -->
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/com/extrahardmode/config/TestRootConfig.java
+++ b/src/test/com/extrahardmode/config/TestRootConfig.java
@@ -23,11 +23,11 @@ package com.extrahardmode.config;
 
 
 import com.extrahardmode.ExtraHardMode;
+import com.extrahardmode.mocks.BukkitTestBootstrap;
 import com.extrahardmode.mocks.MockExtraHardMode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -40,10 +40,22 @@ import static org.junit.Assert.assertTrue;
  * Test the MultiWorldConfig
  */
 
-@RunWith(PowerMockRunner.class)
-//@PrepareForTest({RootConfig.class, ExtraHardMode.class}) //Breaks in JDK 11 apparently
 public class TestRootConfig
 {
+    @BeforeClass
+    public static void beforeClass()
+    {
+        BukkitTestBootstrap.install();
+    }
+
+
+    @AfterClass
+    public static void afterClass()
+    {
+        BukkitTestBootstrap.reset();
+    }
+
+
     //Mock Plugin
     private final ExtraHardMode plugin = new MockExtraHardMode().get();
 

--- a/src/test/com/extrahardmode/features/TestAntiGrinder.java
+++ b/src/test/com/extrahardmode/features/TestAntiGrinder.java
@@ -25,6 +25,7 @@ package com.extrahardmode.features;
 import com.extrahardmode.ExtraHardMode;
 import com.extrahardmode.config.RootConfig;
 import com.extrahardmode.config.RootNode;
+import com.extrahardmode.mocks.BukkitTestBootstrap;
 import com.extrahardmode.mocks.MockBlock;
 import com.extrahardmode.mocks.MockExtraHardMode;
 import com.extrahardmode.mocks.MockLocation;
@@ -36,6 +37,8 @@ import org.bukkit.World;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +47,20 @@ import static org.junit.Assert.assertTrue;
 
 public class TestAntiGrinder
 {
+    @BeforeClass
+    public static void beforeClass()
+    {
+        BukkitTestBootstrap.install();
+    }
+
+
+    @AfterClass
+    public static void afterClass()
+    {
+        BukkitTestBootstrap.reset();
+    }
+
+
     private final ExtraHardMode plugin = new MockExtraHardMode().get();
 
     private final RootConfig CFG = new RootConfig(plugin);

--- a/src/test/com/extrahardmode/mocks/BukkitTestBootstrap.java
+++ b/src/test/com/extrahardmode/mocks/BukkitTestBootstrap.java
@@ -1,0 +1,310 @@
+package com.extrahardmode.mocks;
+
+
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.Server;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemFactory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionEffectTypeCategory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Minimal Bukkit bootstrap for tests that now touch registry-backed API.
+ */
+public final class BukkitTestBootstrap
+{
+    private BukkitTestBootstrap()
+    {
+    }
+
+
+    public static void install()
+    {
+        clearServer();
+
+        Server server = mock(Server.class);
+        Logger logger = Logger.getLogger(BukkitTestBootstrap.class.getName());
+        ItemFactory itemFactory = mock(ItemFactory.class);
+        Map<Class<?>, Registry<?>> bootstrapRegistries = new ConcurrentHashMap<Class<?>, Registry<?>>();
+
+        when(server.getLogger()).thenReturn(logger);
+        when(server.getName()).thenReturn("TestBukkit");
+        when(server.getVersion()).thenReturn("test");
+        when(server.getBukkitVersion()).thenReturn("test");
+        when(server.getItemFactory()).thenReturn(itemFactory);
+        when(itemFactory.asMetaFor(any(ItemMeta.class), any(Material.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(itemFactory.getItemMeta(any(Material.class))).thenReturn(null);
+
+        when(server.getRegistry(any())).thenAnswer(invocation ->
+        {
+            Class<?> registryClass = invocation.getArgument(0);
+            return resolveBootstrapRegistry(bootstrapRegistries, registryClass);
+        });
+
+        Bukkit.setServer(server);
+
+        Registry<?> materialRegistry = Registry.MATERIAL;
+        Registry<?> entityRegistry = Registry.ENTITY_TYPE;
+        Registry<?> effectRegistry = Registry.EFFECT;
+
+        when(server.getRegistry(any())).thenAnswer(invocation ->
+        {
+            Class<?> registryClass = invocation.getArgument(0);
+            if (Material.class.equals(registryClass))
+                return materialRegistry;
+            if (EntityType.class.equals(registryClass))
+                return entityRegistry;
+            if (PotionEffectType.class.equals(registryClass))
+                return effectRegistry;
+            return resolveBootstrapRegistry(bootstrapRegistries, registryClass);
+        });
+    }
+
+
+    public static void reset()
+    {
+        clearServer();
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private static <T extends org.bukkit.Keyed> Registry<T> createFallbackRegistry()
+    {
+        return (Registry<T>) Proxy.newProxyInstance(
+                BukkitTestBootstrap.class.getClassLoader(),
+                new Class<?>[]{Registry.class},
+                new EmptyRegistryHandler());
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private static Registry<PotionEffectType> createPotionRegistry()
+    {
+        return (Registry<PotionEffectType>) Proxy.newProxyInstance(
+                BukkitTestBootstrap.class.getClassLoader(),
+                new Class<?>[]{Registry.class},
+                new PotionRegistryHandler());
+    }
+
+
+    private static Registry<?> resolveBootstrapRegistry(Map<Class<?>, Registry<?>> bootstrapRegistries, Class<?> registryClass)
+    {
+        if (registryClass == null)
+            return createFallbackRegistry();
+
+        Registry<?> registry = bootstrapRegistries.get(registryClass);
+        if (registry != null)
+            return registry;
+
+        Registry<?> createdRegistry = PotionEffectType.class.equals(registryClass) ? createPotionRegistry() : createFallbackRegistry();
+        Registry<?> existingRegistry = bootstrapRegistries.putIfAbsent(registryClass, createdRegistry);
+        return existingRegistry != null ? existingRegistry : createdRegistry;
+    }
+
+
+    private static PotionEffectType getOrCreateEffect(Map<String, PotionEffectType> effects, NamespacedKey key)
+    {
+        return effects.computeIfAbsent(key.toString(), ignored ->
+        {
+            int id = effects.size() + 1;
+            return new TestPotionEffectType(id, key);
+        });
+    }
+
+
+    private static void clearServer()
+    {
+        try
+        {
+            Field serverField = Bukkit.class.getDeclaredField("server");
+            serverField.setAccessible(true);
+            serverField.set(null, null);
+        } catch (ReflectiveOperationException e)
+        {
+            throw new IllegalStateException("Unable to reset Bukkit server singleton for tests", e);
+        }
+    }
+
+
+    private static final class EmptyRegistryHandler implements InvocationHandler
+    {
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args)
+        {
+            String methodName = method.getName();
+            if ("get".equals(methodName) || "match".equals(methodName))
+                return null;
+            if ("getOrThrow".equals(methodName))
+                throw new IllegalArgumentException("Missing test registry entry");
+            if ("stream".equals(methodName))
+                return Stream.empty();
+            if ("iterator".equals(methodName))
+                return Stream.empty().iterator();
+            if ("toString".equals(methodName))
+                return "EmptyRegistryProxy";
+            if ("hashCode".equals(methodName))
+                return System.identityHashCode(proxy);
+            if ("equals".equals(methodName))
+                return proxy == args[0];
+            throw new UnsupportedOperationException("Unsupported registry method: " + methodName);
+        }
+    }
+
+
+    private static final class PotionRegistryHandler implements InvocationHandler
+    {
+        private final Map<String, PotionEffectType> effects = new ConcurrentHashMap<String, PotionEffectType>();
+
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args)
+        {
+            String methodName = method.getName();
+            if ("get".equals(methodName) || "getOrThrow".equals(methodName))
+                return getOrCreateEffect(effects, (NamespacedKey) args[0]);
+            if ("match".equals(methodName))
+            {
+                String input = (String) args[0];
+                if (input == null)
+                    return null;
+
+                NamespacedKey key = NamespacedKey.fromString(input.toLowerCase(Locale.ROOT));
+                if (key == null)
+                    key = NamespacedKey.minecraft(input.toLowerCase(Locale.ROOT));
+                return getOrCreateEffect(effects, key);
+            }
+            if ("stream".equals(methodName))
+                return effects.values().stream();
+            if ("iterator".equals(methodName))
+                return effects.values().iterator();
+            if ("toString".equals(methodName))
+                return "PotionRegistryProxy";
+            if ("hashCode".equals(methodName))
+                return System.identityHashCode(proxy);
+            if ("equals".equals(methodName))
+                return proxy == args[0];
+            throw new UnsupportedOperationException("Unsupported registry method: " + methodName);
+        }
+    }
+
+
+    private static final class TestPotionEffectType extends PotionEffectType
+    {
+        private final int id;
+        private final NamespacedKey key;
+        private final String name;
+
+
+        private TestPotionEffectType(int id, NamespacedKey key)
+        {
+            this.id = id;
+            this.key = key;
+            this.name = key.getKey().toUpperCase(Locale.ROOT);
+        }
+
+
+        @Override
+        public PotionEffect createEffect(int duration, int amplifier)
+        {
+            return new PotionEffect(this, duration, amplifier);
+        }
+
+
+        @Override
+        public boolean isInstant()
+        {
+            return false;
+        }
+
+
+        @Override
+        public PotionEffectTypeCategory getCategory()
+        {
+            return PotionEffectTypeCategory.NEUTRAL;
+        }
+
+
+        @Override
+        public Color getColor()
+        {
+            return Color.WHITE;
+        }
+
+
+        @Override
+        public NamespacedKey getKey()
+        {
+            return key;
+        }
+
+
+        @Override
+        public double getDurationModifier()
+        {
+            return 1.0;
+        }
+
+
+        @Override
+        public int getId()
+        {
+            return id;
+        }
+
+
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+
+        @Override
+        public String getTranslationKey()
+        {
+            return "effect.minecraft." + key.getKey();
+        }
+
+
+        @Override
+        public NamespacedKey getKeyOrThrow()
+        {
+            return key;
+        }
+
+
+        @Override
+        public NamespacedKey getKeyOrNull()
+        {
+            return key;
+        }
+
+
+        @Override
+        public boolean isRegistered()
+        {
+            return true;
+        }
+    }
+}

--- a/src/test/com/extrahardmode/mocks/MockExtraHardMode.java
+++ b/src/test/com/extrahardmode/mocks/MockExtraHardMode.java
@@ -24,7 +24,7 @@ package com.extrahardmode.mocks;
 
 import com.extrahardmode.ExtraHardMode;
 
-import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.mockito.Mockito.mock;
 
 /**
  *

--- a/src/test/com/extrahardmode/modules/TestInventoryWeight.java
+++ b/src/test/com/extrahardmode/modules/TestInventoryWeight.java
@@ -22,6 +22,7 @@
 package com.extrahardmode.modules;
 
 
+import com.extrahardmode.mocks.BukkitTestBootstrap;
 import com.extrahardmode.mocks.MockExtraHardMode;
 import com.extrahardmode.mocks.MockPlayer;
 import com.extrahardmode.mocks.MockPlayerInventory;
@@ -29,6 +30,8 @@ import com.extrahardmode.module.PlayerModule;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,6 +42,20 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestInventoryWeight
 {
+    @BeforeClass
+    public static void beforeClass()
+    {
+        BukkitTestBootstrap.install();
+    }
+
+
+    @AfterClass
+    public static void afterClass()
+    {
+        BukkitTestBootstrap.reset();
+    }
+
+
     private PlayerModule module;
 
     private final Player myPlayer = new MockPlayer("Diemex94").get();

--- a/src/test/com/extrahardmode/service/TestMultiWorldConfig.java
+++ b/src/test/com/extrahardmode/service/TestMultiWorldConfig.java
@@ -28,16 +28,9 @@ import com.extrahardmode.service.config.Mode;
 import com.extrahardmode.service.config.MultiWorldConfig;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.PluginLogger;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-//@PrepareForTest({MultiWorldConfig.class, JavaPlugin.class, PluginLogger.class}) //Breaks in JDK 11 apparently
 public class TestMultiWorldConfig
 {
     private final ExtraHardMode plugin = new MockExtraHardMode().get();


### PR DESCRIPTION
## What changed
- removed PowerMock from the test dependencies and updated Surefire/Mockito for the JDK 25 test run
- added a shared Bukkit test bootstrap so registry-backed Bukkit types can initialize safely in tests
- wired the affected JUnit 4 tests to install and reset that bootstrap around each class

## Why
The upgraded Bukkit API now initializes registry-backed types through `Bukkit.server`. The existing tests touched `RootNode`, `Material`, `EntityType`, and `ItemStack` before a server existed, which caused the failing registry/bootstrap errors.

## Impact
This keeps the test suite on JUnit 4, avoids a broader modernization pass, and restores reliable test execution on the newer Bukkit API and JDK 25.

## Validation
- `mvn -Dtest=TestRootConfig,TestAntiGrinder,TestInventoryWeight test`
- `mvn test`
- `mvn clean package`